### PR TITLE
More card fixes

### DIFF
--- a/characters.lua
+++ b/characters.lua
@@ -2940,7 +2940,7 @@ end,
     local id = 300193 -- GS Fighter
     player:to_grave(Card(id))
     player:to_bottom_deck(Card(id))
-    if not player[5] then
+    if not player.hand[5] then
       player:to_hand(Card(id))
     end
     local mag = min(#player:field_idxs_with_preds(pred.gs), 3)

--- a/characters.lua
+++ b/characters.lua
@@ -3289,11 +3289,10 @@ end,
   buff:apply()
   if player.character.life <= opponent.character.life then
     local buff = GlobalBuff(player)
-    local idx = uniformly(player:field_idxs_with_preds(pred.follower))
+    local idx = uniformly(opponent:field_idxs_with_preds(pred.follower))
     if idx then
-      buff.field[player][idx] = "_ _ +1"
+      buff.field[opponent][idx] = "_ -1 -2"
     end
-    buff.field[opponent][0] = {life={"-", 1}}
     buff:apply()
   end
 end,
@@ -3309,10 +3308,11 @@ end,
     buff.field[player][idx] = "+1 _ +1"
   end
   if player.character.life <= opponent.character.life then
-    local idx = uniformly(opponent:field_idxs_with_preds(pred.follower))
+    local idx = uniformly(player:field_idxs_with_preds(pred.follower))
     if idx then
-      buff.field[opponent][idx] = "_ -1 -2"
+      buff.field[player][idx] = "_ _ +1"
     end
+    buff.field[opponent][0] = {life={"-", 1}}
   end
   buff:apply()
 end,

--- a/skills.lua
+++ b/skills.lua
@@ -6624,6 +6624,7 @@ end,
     buff[idx] = {size={"=", mag}}
   end
   buff:apply()
+  my_card:remove_skill(skill_idx)
 end,
 
 -- Lady Marie Lunen
@@ -6883,6 +6884,7 @@ end,
 [1661] = function(player, my_idx, my_card, skill_idx)
   local mag = 7 - my_card.upgrade_lvl
   OneBuff(player, my_idx, {atk={"+", my_card.size - mag}, sta={"+", my_card.size - mag}, size={"=", mag}}):apply()
+  my_card:remove_skill(skill_idx)
 end,
 
 -- 2nd Princess Hanobelle
@@ -6890,6 +6892,7 @@ end,
 [1662] = function(player, my_idx, my_card, skill_idx)
   local mag = my_card.upgrade_lvl
   OneBuff(player, my_idx, {atk={"+", mag}, sta={"+", mag}}):apply()
+  my_card:remove_skill(skill_idx)
 end,
 
 -- DTD (Muspelheim)

--- a/skills.lua
+++ b/skills.lua
@@ -6536,7 +6536,7 @@ end,
 -- Rice Cake's Power
 [1612] = function(player, my_idx, my_card, skill_idx, other_idx, other_card)
   if other_card then
-    local mag = abs(Card(other_card.id).atk - other_card.atk)
+    local mag = min(5,abs(Card(other_card.id).atk - other_card.atk))
     OneBuff(player, my_idx, {atk={"+", mag}}):apply()
   end
 end,
@@ -6575,8 +6575,8 @@ end,
 -- Moonlight Addition!
 [1616] = function(player, my_idx, my_card)
   local orig = Card(my_card.id)
-  local mag = abs(orig.def - my_card.def)
-  OneBuff(player, my_idx, {atk={"+", mag}, def={"=", orig.def}, sta={"+", mag}}):apply()
+  local mag = abs(orig.size - my_card.size)
+  OneBuff(player, my_idx, {size={"=", orig.size}, def={"+", mag}, sta={"+", mag}}):apply()
 end,
 
 -- Chuseok Linus

--- a/skills.lua
+++ b/skills.lua
@@ -2727,18 +2727,22 @@ end,
 
 -- dark witch seven, brilliant idea!
 [1256] = function(player, my_idx, my_card, skill_idx, other_idx, other_card)
-  local grave_target_idxs = shuffle(player:grave_idxs_with_preds({pred.D}))
+  local grave_target_idxs = shuffle(player:grave_idxs_with_preds(pred.D))
   if #grave_target_idxs > 0 then
-    local opp_target_idxs = shuffle(player.opponent:get_follower_idxs())
-    local buff = OnePlayerBuff(player.opponent)
     for i=1,2 do
-      local grave_target_idx = uniformly(player:grave_idxs_with_preds({pred.D}))
+      local grave_target_idx = uniformly(grave_target_idxs)
       if grave_target_idx then
         player:grave_to_exile(grave_target_idx)
       end
     end
-    for i=1,math.min(2,#opp_target_idxs) do
-      buff[opp_target_idxs[i]] = {atk={"-",1}, def={"-",1}, sta={"-",2}}
+    local opp_target_idx = uniformly(player.opponent:field_idxs_with_preds(pred.follower,
+        function(card) return card ~= other_card end))
+    local buff = OnePlayerBuff(player.opponent)
+    if other_card then
+      buff[other_idx] = {atk={"-",1}, def={"-",1}, sta={"-",2}}
+    end
+    if opp_target_idx then
+      buff[opp_target_idx] = {atk={"-",1}, def={"-",1}, sta={"-",2}}
     end
     buff:apply()
   end

--- a/skills.lua
+++ b/skills.lua
@@ -6880,6 +6880,21 @@ end,
 end,
 
 -- Eisenwane
+-- Nevermore
+[1660] = function(player, my_idx, my_card, skill_idx, other_card)
+  if other_card then
+    local orig = Card(other_card.id)
+    for i = 1,3 do
+	  local ith_skill = other_card.skills[i]
+	  if ith_skill == orig.skills[1] or ith_skill == orig.skills[2] or ith_skill == orig.skills[3] then
+	    other_card:remove_skill(i)
+	    break
+	  end
+    end
+  end
+end,
+
+-- Eisenwane
 -- Awakening
 [1661] = function(player, my_idx, my_card, skill_idx)
   local mag = 7 - my_card.upgrade_lvl

--- a/spells.lua
+++ b/spells.lua
@@ -8400,8 +8400,12 @@ end,
     buff.field[player][idx] = {size={"=", 2}}
     mag = mag + 1
   end
-  for _, idx in ipairs(player:hand_idxs_with_preds()) do
+  for _, idx in ipairs(player:hand_idxs_with_preds(pred.follower)) do
     buff.hand[player][idx] = {size={"=", 1}}
+  end
+  for _, idx in ipairs(player:hand_idxs_with_preds(pred.spell)) do
+    buff.hand[player][idx] = {size={"=", 2}}
+    mag = mag + 1
   end
   for _, idx in ipairs(opponent:field_idxs_with_preds()) do
     buff.field[opponent][idx] = {size={"=", 2}}

--- a/spells.lua
+++ b/spells.lua
@@ -9395,12 +9395,15 @@ end,
   local buff = OnePlayerBuff(player)
   for _, idx in ipairs(player:field_idxs_with_preds(pred.follower, pred.lady)) do
     local c = player.field[idx]
+	local new_size = c.size
     local mag = {}
-    if c.size >= 3 then
+    if new_size >= 3 then
       mag.atk = {"+", 1}
       mag.size = {"-", 1}
-    elseif c.size <= 3 then
-      mag.sta = {"+", c.size}
+	  new_size = new_size - 1
+	end
+    if new_size <= 3 then
+      mag.sta = {"+", new_size}
     end
     buff[idx] = mag
   end

--- a/spells.lua
+++ b/spells.lua
@@ -9648,9 +9648,9 @@ end,
     player:field_to_top_deck(my_idx)
   else
     player.shuffles = opponent.shuffles
-    local idx = uniformly(player:field_idxs_with_preds(pred.follower))
+    local idx = uniformly(opponent:field_idxs_with_preds(pred.follower))
     if idx then
-      OneBuff(player, idx, {def={"-", player.shuffles}}):apply()
+      OneBuff(opponent, idx, {def={"-", player.shuffles}}):apply()
     end
   end
 end,

--- a/spells.lua
+++ b/spells.lua
@@ -9378,7 +9378,7 @@ end,
     mag = mag + (pred.follower(player.deck[i]) and 1 or 0)
   end
   local pred_size = function(c) return c.size < mag end
-  local idx = uniformly(opponent:field_idxs_with_preds(pred.spell))
+  local idx = opponent:field_idxs_with_preds(pred.spell, pred_size)[1]
   if idx then
     OneImpact(opponent, idx):apply()
     opponent:field_to_exile(idx)


### PR DESCRIPTION
Various bug fixes for cards currently unavailable in the game:
* Fixed Maid Mother Demon and Knight Mother Demon (swapped their lower life effects).
* Fixed GS Executive Binch (made her check for a 5th card in the player's hand instead of in the player).
* Fixed Underground Library (made it target the first opposing spell with low enough size instead of a random opposing spell).
* Fixed Secret Garden (made the sta buff no longer overlook followers that fill both criteria). I've made the assumption that the size reduction is supposed to happen before the check for the sta buff.
* Fixed Life of Study (made it debuff an opposing follower instead of the player's follower).
* Fixed Library Club Gatekeeper and 2nd Princess Hanobelle, and partially fixed Empire Eisenwane (made Book's Harmony, Princess Ward, and Awakening respectively remove themselves after use).
* Fixed the other part of Empire Eisenwane (created the Nevermore skill).
* Fixed Chuseok Asmis and Chuseok Linus (made Chuseok Asmis reset her size and buff her def/sta and added the cap to Chuseok Linus).
* Fixed Prohibition (made spells in the player's hand be size 2 instead of 1).
* Fixed Dark Witch Seven (made her target the defender and a random other opposing follower instead of 2 random opposing followers).